### PR TITLE
unmuting all bithoundrc dependency checks

### DIFF
--- a/.bithoundrc
+++ b/.bithoundrc
@@ -1,10 +1,6 @@
 {
   "dependencies": {
-    "mute": [
-      "chai",
-      "gulp",
-      "yargs"
-    ]
+    "mute": []
   },
   "ignore": [
     "fixtures/**"


### PR DESCRIPTION
Muting these is just bad, and it breaks bithound. Instead, I disabled some of these checks from failing builds, while still being able to see them in the bithound report when I check it manually.