### PR TITLE
caching node_modules for appveyor builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,10 @@ environment:
     - nodejs_version: "0.12"
     # io.js
     - nodejs_version: "1"
+    
+# Cache some things so that the build runs faster
+cache:
+  - node_modules
 
 # Install scripts. (runs after repo cloning)
 install:
@@ -17,6 +21,8 @@ install:
   - ps: Install-Product node $env:nodejs_version
   # install modules
   - npm install
+  # run an upgrade, since we are now caching
+  - npm upgrade
   
 # Post-install test scripts.
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,9 +19,12 @@ cache:
 install:
   # Get the latest stable version of Node.js or io.js
   - ps: Install-Product node $env:nodejs_version
-  # install modules
+  # install modules -- this won't do much on cached builds
   - npm install
-  # run an upgrade, since we are now caching
+  # prune stuff that is not needed, in case no-longer-used
+  # cache files are available
+  - npm prune
+  # run an upgrade, to update outdated cached libs
   - npm upgrade
   
 # Post-install test scripts.


### PR DESCRIPTION
AppVeyor builds have been painfully slow, so when I do a lot of development, there is a ton of waiting around to merge PRs. This is annoying af.

To try to address this, I have added the `node_modules` folder to the cache. I have also added `npm prune` and `npm upgrade` to the script, to make sure that `node_modules` is cleaned up and updated, while hopefully working much faster. This _should_ be safe enough, but I will be keeping an eye... and maybe trying to figure out how to clear the cache periodically.

This should hopefully make multiple builds in quick succession run much faster. Let's see how this goes. I hope it doesn't turn out to be a huge pain.